### PR TITLE
Improve performance

### DIFF
--- a/src/LTTB.elm
+++ b/src/LTTB.elm
@@ -73,17 +73,23 @@ downsample input =
         data =
             List.sortBy x input.data
 
-        triangleArea : a -> a -> Point -> Float
+        toPoint : a -> Point
+        toPoint inp =
+            Point (x inp) (y inp)
+
+        triangleArea : Point -> a -> Point -> Float
         triangleArea a b c =
             -- Area of a triangle with the three input points as its corners
-            abs (x a * (y b - c.y) + x b * (c.y - y a) + c.x * (y a - y b)) / 2
+            abs (a.x * (y b - c.y) + x b * (c.y - a.y) + c.x * (a.y - y b))
 
         listAverage : List a -> Point
         listAverage list_ =
             let
+                length =
+                    toFloat (List.length list_)
+
                 avg list acc =
-                    List.sum (List.map acc list)
-                        / toFloat (List.length list)
+                    sumBy acc list / length
             in
             Point (avg list_ x) (avg list_ y)
 
@@ -113,9 +119,15 @@ downsample input =
                 iter : a -> List a -> List a -> List (List a) -> List a
                 iter previous current next rest =
                     let
+                        previousPoint =
+                            toPoint previous
+
+                        nextAverage =
+                            listAverage next
+
                         selected =
                             List.Extra.maximumBy
-                                (\j -> triangleArea previous j (listAverage next))
+                                (\j -> triangleArea previousPoint j nextAverage)
                                 current
                                 |> Maybe.withDefault previous
                     in
@@ -146,6 +158,11 @@ downsample input =
 
             [] ->
                 []
+
+
+sumBy : (a -> number) -> List a -> number
+sumBy fn list =
+    List.foldl (\item total -> total + fn item) 0 list
 
 
 splitIn : Int -> List a -> List (List a)


### PR DESCRIPTION
Hi and thanks for this very nice package.

We are using it at work in quite a performance sensitive area and it has been slowing us down a little bit. So I thought I would take a look if we can optimise the code a bit:

<details open>
 <summary>Chrome 91 on OSX 11.2.3</summary>
 <img width="562" alt="Screenshot 2021-06-16 at 13 55 16" src="https://user-images.githubusercontent.com/69144/122208046-7d309f00-ceab-11eb-9f44-1bc85a6ff5b1.png">
</details>

<details>
  <summary>Safari 14 on OSX 11.2.3</summary>
  <img width="609" alt="Safari - Final Benchmark 2021-06-16 at 15 31 40" src="https://user-images.githubusercontent.com/69144/122222150-a99fe780-ceba-11eb-976a-8d74b1bf15f4.png">
</details>

<details>
  <summary>Firefox 86 on OSX 11.2.3</summary>
  <img width="596" alt="Firefox - Benchmark Final 2021-06-16 at 15 49 07" src="https://user-images.githubusercontent.com/69144/122222261-c2a89880-ceba-11eb-8370-effda8faea85.png">
</details>



I think the regression in the 90% case is that the buckets are so small that precomputing and storing is more expensive than just computing from scratch, although I haven't dug into it deeper, as performance in the 90% case is in general very good.

Most of the improvements here simply avoid recomputing stuff more than once.

There is another nice performance improvement by removing the sort and asking the user to sort their data. As a user this would be very preferable to me, as our data is already sorted. Since this would be a (silent) breaking change, I didn't include it in this PR, but perhaps something to consider for the future of this package.

You can see my setup for this [on this branch](https://github.com/RalfNorthman/elm-lttb/compare/master...gampleman:benchmarking?expand=1), one can generate the benchmarking setup with `elm make --optimize benchmarks/Perf.elm` (in case you wish to replicate the above measurements).